### PR TITLE
Add: LibreJS compliant AGPL notice to defpage macro

### DIFF
--- a/views.lisp
+++ b/views.lisp
@@ -1,19 +1,6 @@
 (in-package #:compost)
 
-(defmacro defpage  (name lambda-list
-                    (&key (stylesheets (list "/css/main.css")) scripts (title ""))
-                    &body body)
-  (let ((page-name (intern (format nil "PAGE/~a" name))))
-    `(defun ,page-name ,lambda-list
-       (with-html-string
-         (:doctype)
-         (:html
-          (:head
-           (:title ,title)
-           (dolist (css (list ,@stylesheets))
-             (:link :rel "stylesheet" :href css))
-           (:script
-            "/*
+(defparameter +librejs-blanket-license+ "/*
 @licstart The following is the entire license notice for the
 JavaScript code in this page.
 
@@ -32,8 +19,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 @licend The above is the entire license notice
 for the JavaScript code in this page.
-*/"
-            ))
+*/")
+
+(defmacro defpage  (name lambda-list
+                    (&key (stylesheets (list "/css/main.css")) scripts (title ""))
+                    &body body)
+  (let ((page-name (intern (format nil "PAGE/~a" name))))
+    `(defun ,page-name ,lambda-list
+       (with-html-string
+         (:doctype)
+         (:html
+          (:head
+           (:title ,title)
+           (dolist (css (list ,@stylesheets))
+             (:link :rel "stylesheet" :href css))
+           (:script +librejs-blanket-license+))
           (:body
            ,@body
            (dolist (js (list ,@scripts))

--- a/views.lisp
+++ b/views.lisp
@@ -10,8 +10,30 @@
          (:html
           (:head
            (:title ,title)
-           (dolist (css (list ,@stylesheets)) 
-             (:link :rel "stylesheet" :href css)))
+           (dolist (css (list ,@stylesheets))
+             (:link :rel "stylesheet" :href css))
+           (:script
+            "/*
+@licstart The following is the entire license notice for the
+JavaScript code in this page.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+@licend The above is the entire license notice
+for the JavaScript code in this page.
+*/"
+            ))
           (:body
            ,@body
            (dolist (js (list ,@scripts))


### PR DESCRIPTION
technically there is supposed to be a Copyright <year> <author> notice along with the license. but this at the least makes it pass the LibreJS check. thus, any inline javascript on the page should be covered. I'm still not certain what happens if external scripts are referenced, iirc they will not pass unless they have their own notices (a la prettier.js on gnu.org sites)

![image](https://user-images.githubusercontent.com/760104/103389667-e24b3080-4ad5-11eb-9373-12ca44f8b74e.png)
